### PR TITLE
Fix sample test

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     compileOnly(gradleKotlinDsl())
     implementation(kotlin("stdlib", "1.1.2"))
     implementation("com.android.tools.build:gradle:3.0.1")
+    testCompile("junit:junit-dep:4.11")
 }
 
 


### PR DESCRIPTION
Summary: 
`./gradlew build` fails because there was no jUnit to run `ExampleUnitTest` 