### PR TITLE
Upload correct ABI split to firebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ gradle.properties
 
 # General
 .DS_Store
+/.gradle/

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -22,3 +22,4 @@ gradle.properties
 
 # Binaries
 /out/**
+/.gradle/

--- a/plugin/src/main/java/com/appunite/firebasetestlabplugin/FirebaseTestLabPlugin.kt
+++ b/plugin/src/main/java/com/appunite/firebasetestlabplugin/FirebaseTestLabPlugin.kt
@@ -7,6 +7,7 @@ import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariantOutput
+import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.TestVariant
 import com.appunite.firebasetestlabplugin.cloud.CloudTestResultDownloader
 import com.appunite.firebasetestlabplugin.cloud.FirebaseTestLabProcessCreator
@@ -524,7 +525,16 @@ private fun resolveAssemble(variant: TestVariant): Task = try {
 private fun resolveApk(variant: ApkVariant, baseVariantOutput: BaseVariantOutput): File =
     try {
         val applicationProvider = variant.packageApplicationProvider.get()
-        applicationProvider.let { File(it.outputDirectory, it.apkNames.toList()[0]) }
+        val filter = baseVariantOutput.filters.firstOrNull { it.filterType == VariantOutput.ABI }
+        applicationProvider.let {
+            var filename: String
+            if (baseVariantOutput is ApkVariantOutput) {
+                filename = baseVariantOutput.outputFileName
+            } else {
+                filename = it.apkNames.toList()[0]
+            }
+            File(it.outputDirectory, filename)
+        }
     } catch (e: Exception) {
         when (e) {
             is IllegalStateException, is IndexOutOfBoundsException -> baseVariantOutput.outputFile

--- a/plugin/src/main/java/com/appunite/firebasetestlabplugin/FirebaseTestLabPlugin.kt
+++ b/plugin/src/main/java/com/appunite/firebasetestlabplugin/FirebaseTestLabPlugin.kt
@@ -525,7 +525,6 @@ private fun resolveAssemble(variant: TestVariant): Task = try {
 private fun resolveApk(variant: ApkVariant, baseVariantOutput: BaseVariantOutput): File =
     try {
         val applicationProvider = variant.packageApplicationProvider.get()
-        val filter = baseVariantOutput.filters.firstOrNull { it.filterType == VariantOutput.ABI }
         applicationProvider.let {
             var filename: String
             if (baseVariantOutput is ApkVariantOutput) {

--- a/plugin/src/main/java/com/appunite/firebasetestlabplugin/cloud/FirebaseTestLabProcessCreator.kt
+++ b/plugin/src/main/java/com/appunite/firebasetestlabplugin/cloud/FirebaseTestLabProcessCreator.kt
@@ -23,7 +23,7 @@ data class ProcessData(
 ) : Serializable
 
 object FirebaseTestLabProcessCreator {
-
+    private var execute: (ProcessData) -> Process = {processData -> createProcess(processData).start()}
     private val resultMessageMap = mapOf(
             0 to "All test executions passed.",
             1 to "A general failure occurred. Possible causes include: a filename that does not exist, or an HTTP/network error.",
@@ -35,8 +35,12 @@ object FirebaseTestLabProcessCreator {
             20 to "A test infrastructure error occurred."
     )
 
+    fun setExecutor(executor: (ProcessData) -> Process){
+        execute = executor
+    }
+
     fun callFirebaseTestLab(processData: ProcessData): TestResults {
-        val process: Process = createProcess(processData).start()
+        val process: Process = execute(processData)
         val resultCode: Int = process.let {
             it.errorStream.bufferedReader().forEachLine { errorInfo -> println(errorInfo) }
             it.inputStream.bufferedReader().forEachLine { info -> println(info) }

--- a/plugin/src/main/java/com/appunite/firebasetestlabplugin/cloud/FirebaseTestLabProcessCreator.kt
+++ b/plugin/src/main/java/com/appunite/firebasetestlabplugin/cloud/FirebaseTestLabProcessCreator.kt
@@ -23,7 +23,7 @@ data class ProcessData(
 ) : Serializable
 
 object FirebaseTestLabProcessCreator {
-    private var execute: (ProcessData) -> Process = {processData -> createProcess(processData).start()}
+    private var execute: (ProcessData) -> Process = { processData -> createProcess(processData).start() }
     private val resultMessageMap = mapOf(
             0 to "All test executions passed.",
             1 to "A general failure occurred. Possible causes include: a filename that does not exist, or an HTTP/network error.",
@@ -35,7 +35,7 @@ object FirebaseTestLabProcessCreator {
             20 to "A test infrastructure error occurred."
     )
 
-    fun setExecutor(executor: (ProcessData) -> Process){
+    fun setExecutor(executor: (ProcessData) -> Process) {
         execute = executor
     }
 

--- a/plugin/src/test/java/com/appunite/firebasetestlabplugin/ApplicationIntegrationTest.kt
+++ b/plugin/src/test/java/com/appunite/firebasetestlabplugin/ApplicationIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.appunite.firebasetestlabplugin
 
 import com.android.build.gradle.AppExtension
+import com.appunite.firebasetestlabplugin.cloud.FirebaseTestLabProcessCreator
 import junit.framework.TestCase.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -56,7 +57,7 @@ class ApplicationIntegrationTest {
     fun `run firebaseTestLabSetup install gcloud`() {
         val simpleProject = File(javaClass.getResource("simple").file)
         val project = prepareSimpleProject()
-	project.plugins.apply("firebase.test.lab")
+        project.plugins.apply("firebase.test.lab")
         project.configure<FirebaseTestLabPluginExtension> {
             googleProjectId = "test"
             keyFile = File(simpleProject, "key.json")
@@ -71,7 +72,7 @@ class ApplicationIntegrationTest {
     fun `ensure after evaluation tasks presented`() {
         val simpleProject = File(javaClass.getResource("simple").file)
         val project = prepareSimpleProject()
-	project.plugins.apply("firebase.test.lab")
+        project.plugins.apply("firebase.test.lab")
         project.configure<FirebaseTestLabPluginExtension> {
             googleProjectId = "test"
             keyFile = File(simpleProject, "key.json")
@@ -134,6 +135,13 @@ class ApplicationIntegrationTest {
         assertTrue(project.getTasksByName("firebaseTestLabExecuteDebugInstrumentationMyDeviceX8664Debug", false).isNotEmpty())
         assertTrue(project.getTasksByName("firebaseTestLabExecuteDebugInstrumentationMyDeviceArmeabiV7aDebug", false).isNotEmpty())
         assertTrue(project.getTasksByName("firebaseTestLabExecuteDebugInstrumentationMyDeviceUniversalDebug", false).isNotEmpty())
+        val x86 = project.getTasksByName("firebaseTestLabExecuteDebugInstrumentationMyDeviceX86Debug", false).first();
+        FirebaseTestLabProcessCreator.setExecutor({ processData ->
+            assertTrue("Unexpected app name ${processData.apk}",
+                    processData.apk.toString().contains("test-x86-debug.apk"))
+            ProcessBuilder("whoami").start()
+        })
+        x86.actions.forEach { it.execute(x86) }
     }
 
     @Test

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.github.piotrmadry:FirebaseTestLab-Android:master-SNAPSHOT'
+        classpath 'firebase.test.lab:plugin:2.5.0'
     }
 }
 


### PR DESCRIPTION
Since 2.5.0 the APK uploaded to firebase is always the first one:
```
applicationProvider.let { File(it.outputDirectory, it.apkNames.toList()[0]) }
```
Instead we should upload the APK specified by baseVariantOutput.

The PR also changes dependency of the `sample` project because it's not possible to compile it (it depends on Jitpack version of this plugin, but Jitpack can only build the plugin if dependencies of `sample` are resolved, leading to a circular dependency).