### PR TITLE
added flavor check to apk path resolution

### DIFF
--- a/plugin/src/main/java/com/appunite/firebasetestlabplugin/FirebaseTestLabPlugin.kt
+++ b/plugin/src/main/java/com/appunite/firebasetestlabplugin/FirebaseTestLabPlugin.kt
@@ -217,7 +217,7 @@ class FirebaseTestLabPlugin : Plugin<Project> {
     
                     val extensionType: ExtensionType = when (androidExtension) {
                         is LibraryExtension -> ExtensionType.Library(testVariant)
-                        is AppExtension -> ExtensionType.Application(testVariant, androidExtension.applicationVariants.toList().firstOrNull { it.buildType == testVariant.buildType }!!)
+                        is AppExtension -> ExtensionType.Application(testVariant, androidExtension.applicationVariants.toList().firstOrNull { it.buildType == testVariant.buildType && it.flavorName == testVariant.flavorName }!!)
                         else -> throw IllegalStateException("Only application and library modules are supported")
                     }
                     


### PR DESCRIPTION
In a project with multiple flavors the FirebaseTestLab-Android plugin is sometimes generating a wrong path to the apk as different buildVariants are mixed (see usage of `buildVariant1`and `buildVariant2` in the following build log). Selecting the used buildVariant not only be the buildType but also by the flavorName resolves this issue.
```
> Task :app:firebaseTestLabExecuteBuildVariant2DebugInstrumentationS7BuildVariant2Debug
Uploading [<project path>/app/build/outputs/apk/buildVariant1/debug/app-buildVariant2-debug.apk] to Firebase Test Lab...
ERROR: (gcloud.firebase.test.android.run) [<project path>/app/build/outputs/apk/buildVariant1/debug/app-buildVariant2-debug.apk] not found or not accessible
```