### PR TITLE
Fix escaping in exclusion filter

### DIFF
--- a/plugin/src/main/java/com/appunite/firebasetestlabplugin/cloud/CloudTestResultDownloader.kt
+++ b/plugin/src/main/java/com/appunite/firebasetestlabplugin/cloud/CloudTestResultDownloader.kt
@@ -43,7 +43,7 @@ internal class CloudTestResultDownloader(
             excludeQuery.append("|.*\\.results$")
         }
         if (!resultsTypes.logcat) {
-            excludeQuery.append("|.*\\logcat$")
+            excludeQuery.append("|.*logcat$")
         }
         if (!resultsTypes.video) {
             excludeQuery.append("|.*\\.mp4$")


### PR DESCRIPTION
The files that should be ignored are called simply `logcat` or `0000_logcat`. The extra backslash is not working correctly, with the current version of GCloud SDK it's throwing an exception `CommandException: Invalid exclude filter (".*\.txt$|.*\.apk$|.*\logcat$|.*\.mp4$|.*\.txt$")`